### PR TITLE
fix: compilation issue in Xcode 13

### DIFF
--- a/Classes/HUD/M13ProgressHUD.m
+++ b/Classes/HUD/M13ProgressHUD.m
@@ -407,7 +407,7 @@
 }
 
 - (void)deviceOrientationDidChange:(NSNotification *)notification {
-    UIDeviceOrientation deviceOrientation = [notification.object orientation];
+    UIDeviceOrientation deviceOrientation = [(UIDevice *)notification.object orientation];
     
     if (_shouldAutorotate && UIDeviceOrientationIsValidInterfaceOrientation(deviceOrientation)) {
         if (UIDeviceOrientationIsPortrait(deviceOrientation)) {


### PR DESCRIPTION
Corrects the error thrown by Xcode 13 when using the library:

> Multiple methods named 'orientation' found with mismatched result, parameter type or attributes